### PR TITLE
fix(doc): error on docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -17,10 +17,10 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://robbenti.github.io/',
+  url: 'https://docs.oss-monitoring.radicalbit.ai/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: 'github-pages-test/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Here the error:
<img width="698" alt="Screenshot 2024-06-19 alle 19 24 03" src="https://github.com/radicalbit/radicalbit-x/assets/127778257/d5242b4d-abf1-486e-a81d-cc278ff87fea">

You can see it here: https://docs.oss-monitoring.radicalbit.ai/